### PR TITLE
Fix some issues with the shield filter

### DIFF
--- a/src/main/java/mcjty/rftoolsbuilder/modules/shield/filters/AnimalFilter.java
+++ b/src/main/java/mcjty/rftoolsbuilder/modules/shield/filters/AnimalFilter.java
@@ -1,8 +1,8 @@
 package mcjty.rftoolsbuilder.modules.shield.filters;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.MobEntity;
 import net.minecraft.entity.monster.IMob;
-import net.minecraft.entity.passive.AnimalEntity;
 
 public class AnimalFilter extends AbstractShieldFilter {
 
@@ -10,7 +10,7 @@ public class AnimalFilter extends AbstractShieldFilter {
 
     @Override
     public boolean match(Entity entity) {
-        return entity instanceof AnimalEntity && !(entity instanceof IMob);
+        return entity instanceof MobEntity && !(entity instanceof IMob);
     }
 
     @Override

--- a/src/main/java/mcjty/rftoolsbuilder/modules/shield/filters/PlayerFilter.java
+++ b/src/main/java/mcjty/rftoolsbuilder/modules/shield/filters/PlayerFilter.java
@@ -34,12 +34,12 @@ public class PlayerFilter extends AbstractShieldFilter {
             return false;
         }
 
-        if (name == null) {
+        if (name == null || name.isEmpty()) {
             return true;
         }
 
-        PlayerEntity PlayerEntity = (PlayerEntity) entity;
-        return name.equals(PlayerEntity.getName());
+        PlayerEntity playerEntity = (PlayerEntity) entity;
+        return name.equals(playerEntity.getGameProfile().getName());
     }
 
     @Override


### PR DESCRIPTION
The following bugs fixed this PR:
- Player gets hurt with filter because [player counted as a passive mob for damaging](https://github.com/McJtyMods/RFToolsBuilder/blob/1587dd597b1309c4b65902d36665469cffe3674f/src/main/java/mcjty/rftoolsbuilder/modules/shield/blocks/ShieldingBlock.java#L290) (see with `Player Pass, Passive: SolDmg`)
- Non living entities being treated as items([1](https://github.com/McJtyMods/RFToolsBuilder/blob/1587dd597b1309c4b65902d36665469cffe3674f/src/main/java/mcjty/rftoolsbuilder/modules/shield/blocks/ShieldingBlock.java#L186), [2](https://github.com/McJtyMods/RFToolsBuilder/blob/1587dd597b1309c4b65902d36665469cffe3674f/src/main/java/mcjty/rftoolsbuilder/modules/shield/blocks/ShieldingBlock.java#L240)) e.g. arrows and wither skull projectiles (see with `Item: Pass, Default:Solid`)
- Bats [not colliding](https://github.com/McJtyMods/RFToolsBuilder/blob/1587dd597b1309c4b65902d36665469cffe3674f/src/main/java/mcjty/rftoolsbuilder/modules/shield/blocks/ShieldingBlock.java#L170) with passive filter set but [do take damage](https://github.com/McJtyMods/RFToolsBuilder/blob/1587dd597b1309c4b65902d36665469cffe3674f/src/main/java/mcjty/rftoolsbuilder/modules/shield/blocks/ShieldingBlock.java#L290) (see with `Passive: Solid` and for damage `Passive: Damage`)

Also reduced redundant code for easier maintainability:
- Switched to using `ShieldFilter#match` for each of the filters
- Combined `checkEntityCD`, `checkPlayerCD`, `checkEntityDamage` and `checkPlayerDamage` into `checkEntityAction`

Let me know if any changes are needed for this PR and thanks for awesome mods. :3