### PR TITLE
Make ShapeCardItem selection process work with the ShieldProjector.

### DIFF
--- a/src/main/java/mcjty/rftoolsbuilder/modules/builder/items/ShapeCardItem.java
+++ b/src/main/java/mcjty/rftoolsbuilder/modules/builder/items/ShapeCardItem.java
@@ -9,6 +9,7 @@ import mcjty.rftoolsbuilder.modules.builder.BuilderConfiguration;
 import mcjty.rftoolsbuilder.modules.builder.BuilderModule;
 import mcjty.rftoolsbuilder.modules.builder.blocks.BuilderTileEntity;
 import mcjty.rftoolsbuilder.modules.builder.client.GuiShapeCard;
+import mcjty.rftoolsbuilder.modules.shield.blocks.ShieldProjectorTileEntity;
 import mcjty.rftoolsbuilder.shapes.IFormula;
 import mcjty.rftoolsbuilder.shapes.Shape;
 import mcjty.rftoolsbuilder.shapes.ShapeModifier;
@@ -135,13 +136,13 @@ public class ShapeCardItem extends Item implements INBTPreservingIngredient, ITo
             int mode = getMode(stack);
             if (mode == MODE_NONE) {
                 if (player.isShiftKeyDown()) {
-                    if (world.getBlockEntity(pos) instanceof BuilderTileEntity) {
+                    if (world.getBlockEntity(pos) instanceof BuilderTileEntity || world.getBlockEntity(pos) instanceof ShieldProjectorTileEntity) {
                         setCurrentBlock(stack, GlobalPos.of(world.dimension(), pos));
                         Logging.message(player, TextFormatting.GREEN + "Now select the first corner");
                         setMode(stack, MODE_CORNER1);
                         setCorner1(stack, null);
                     } else {
-                        Logging.message(player, TextFormatting.RED + "You can only do this on a builder!");
+                        Logging.message(player, TextFormatting.RED + "You can only do this on a builder or shield Projector!");
                     }
                 } else {
                     return ActionResultType.SUCCESS;

--- a/src/main/resources/assets/rftoolsbuilder/lang/en_us.json
+++ b/src/main/resources/assets/rftoolsbuilder/lang/en_us.json
@@ -61,7 +61,7 @@
   "message.rftoolsbuilder.space_chamber_card.extra": "(final cost depends on infusion level)",
 
   "message.rftoolsbuilder.shape_card.warning": "Disabled in config!",
-  "message.rftoolsbuilder.shape_card.header": "This card represents an area that can be used by the shield or builder. Sneak right click on builder to start mark mode, then right click to mark two corners of wanted area",
+  "message.rftoolsbuilder.shape_card.header": "This card represents an area that can be used by the shield or builder. Sneak right click on builder or shield projector to start mark mode, then right click to mark two corners of wanted area",
   "message.rftoolsbuilder.shape_card.shape": "Shape: ",
   "message.rftoolsbuilder.shape_card.dimension": "Dimension: ",
   "message.rftoolsbuilder.shape_card.offset": "Offset: ",


### PR DESCRIPTION
Makes it possible to start ShapeCard selection process with the ShieldProjector just like it does with the Builder.
Fixes this issue: [McJtyMods/RFTools/#1306](https://github.com/McJtyMods/RFTools/issues/1306).