### PR TITLE
pass in fake player to builder's loot context

### DIFF
--- a/src/main/java/mcjty/rftoolsbuilder/modules/builder/blocks/BuilderTileEntity.java
+++ b/src/main/java/mcjty/rftoolsbuilder/modules/builder/blocks/BuilderTileEntity.java
@@ -1226,6 +1226,7 @@ public class BuilderTileEntity extends TickingTileEntity implements IHudSupport 
 //                            .withRandom(level.random)
                             .withParameter(LootContextParams.ORIGIN, new Vec3(srcPos.getX(), srcPos.getY(), srcPos.getZ()))
                             .withParameter(LootContextParams.TOOL, getHarvesterTool(silk, fortune))
+                            .withParameter(LootContextParams.THIS_ENTITY, fakePlayer)
                             .withOptionalParameter(LootContextParams.BLOCK_ENTITY, level.getBlockEntity(srcPos));
                     if (fortune > 0) {
                         builder.withLuck(fortune);


### PR DESCRIPTION
makes it so that the builder's fake player gets passed into the loot context

fixes #122 