### PR TITLE
1.20 Made Builder Block NBT data copying configurable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,12 +41,34 @@ sourceSets.main.resources {
     srcDir 'src/generated/resources'
 }
 
+repositories {
+    maven {
+        url = "https://cursemaven.com"
+        content {
+            includeGroup "curse.maven"
+        }
+    }
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = "Modrinth"
+                url = "https://api.modrinth.com/maven"
+            }
+        }
+        filter {
+            includeGroup "maven.modrinth"
+        }
+    }
+}
+
 dependencies {
     mc()
     top()
     jei()
     mcjtylib()
     rftoolsbase()
+    runtimeOnly(fg.deobf("curse.maven:rftools-utility-342466:5283900"))
+    runtimeOnly(fg.deobf("curse.maven:rftools-power-290209:5283901"))
 }
 
 cfdeps(['the-one-probe'], ['mcjtylib', 'rftools-base'], [])

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+1.20-6.0.6:
+- PHOBOSS added a block blacklist/whitelist configuration option to allow NBT transfer of selected blocks
+
 1.20-6.0.5:
 - Update to latest McJtyLib
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+1.20-6.0.7:
+- PHOBOSS fixed liquids (tested on lava and water) melting shield projections
+
 1.20-6.0.6:
 - PHOBOSS added a block blacklist/whitelist configuration option to allow NBT transfer of selected blocks
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 modname=RFToolsBuilder
-version=1.20-6.0.5
+version=1.20-6.0.6
 curse_type=release
 projectId=347706
 projectSlug=rftools-builder

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 modname=RFToolsBuilder
-version=1.20-6.0.6
+version=1.20-6.0.7
 curse_type=release
 projectId=347706
 projectSlug=rftools-builder

--- a/src/main/java/mcjty/rftoolsbuilder/modules/builder/BlockInformation.java
+++ b/src/main/java/mcjty/rftoolsbuilder/modules/builder/BlockInformation.java
@@ -13,7 +13,7 @@ import java.util.Map;
 public class BlockInformation {
 
     private static Map<ResourceLocation,BlockInformation> blockInformationMap = null;
-
+    private static Map<ResourceLocation,Boolean> blackWhiteListedNBTBlocksMap = null;
     private final ResourceLocation blockName;
     private final SupportBlock.SupportStatus blockLevel;
     private final double costFactor;
@@ -34,6 +34,23 @@ public class BlockInformation {
             return ROTATE_mfff;
         } else {
             return ROTATE_invalid;
+        }
+    }
+
+    private static void initBlackWhiteListedNBTBlocksMap() {
+        if (blackWhiteListedNBTBlocksMap == null) {
+            blackWhiteListedNBTBlocksMap = new HashMap<>();
+            List<? extends String> blocks = BuilderConfiguration.blackWhiteListedNBTBlocks.get();
+            Boolean whitelist = false;
+            for (String block : blocks) {
+                if (block.contains("=")) {
+                    String[] split = block.split("=");
+                    block = split[0];
+                    whitelist = Boolean.valueOf(split[1]);
+                }
+                ResourceLocation id = new ResourceLocation(block);
+                blackWhiteListedNBTBlocksMap.put(id,whitelist);
+            }
         }
     }
 
@@ -85,6 +102,11 @@ public class BlockInformation {
     public static BlockInformation getBlockInformation(Block block) {
         initMap();
         return blockInformationMap.get(Tools.getId(block));
+    }
+
+    public static boolean shouldTransferNBT(Block block) {
+        initBlackWhiteListedNBTBlocksMap();
+        return blackWhiteListedNBTBlocksMap.getOrDefault(Tools.getId(block), false);
     }
 
     public SupportBlock.SupportStatus getBlockLevel() {

--- a/src/main/java/mcjty/rftoolsbuilder/modules/builder/BuilderConfiguration.java
+++ b/src/main/java/mcjty/rftoolsbuilder/modules/builder/BuilderConfiguration.java
@@ -29,6 +29,11 @@ public class BuilderConfiguration {
     };
     public static ForgeConfigSpec.ConfigValue<List<? extends String>> blackWhiteListedBlocks;
 
+    private static String[] blackWhiteListedNBTBlocksAr = new String[] {
+            "minecraft:chest=false"
+    };
+    public static ForgeConfigSpec.ConfigValue<List<? extends String>> blackWhiteListedNBTBlocks;
+
     public static ForgeConfigSpec.BooleanValue showProgressHud;
 
     public static ForgeConfigSpec.IntValue maxSpaceChamberDimension;
@@ -93,6 +98,9 @@ public class BuilderConfiguration {
         blackWhiteListedBlocks = SERVER_BUILDER
                 .comment("This is a list of blocks that are either blacklisted or whitelisted from the Builder when it tries to move tile entities (format <id>=<cost>)")
                 .defineList("blackWhiteListedBlocks", Lists.newArrayList(blackWhiteListedBlocksAr), s -> s instanceof String);
+        blackWhiteListedNBTBlocks = SERVER_BUILDER
+                .comment("Whitelist or blacklist block NBT data from being transferred over, set `true` to whitelist block, set `false` to blacklist block, every block not included in the list is blacklisted by default (format <id>=<boolean>)")
+                .defineList("blackWhiteListedNBTBlocks", Lists.newArrayList(blackWhiteListedNBTBlocksAr), s -> s instanceof String);
         maxSpaceChamberDimension = SERVER_BUILDER
                 .comment("Maximum dimension for the space chamber")
                 .defineInRange("maxSpaceChamberDimension", 128, 0, 100000);

--- a/src/main/java/mcjty/rftoolsbuilder/modules/shield/blocks/ShieldingBlock.java
+++ b/src/main/java/mcjty/rftoolsbuilder/modules/shield/blocks/ShieldingBlock.java
@@ -51,6 +51,7 @@ public class ShieldingBlock extends Block implements EntityBlock {
 
     public ShieldingBlock() {
         super(BlockBehaviour.Properties.of()
+                .forceSolidOn()
                 .sound(SoundType.GLASS)
                 .noOcclusion()
                 .isRedstoneConductor((state, world, pos) -> false)


### PR DESCRIPTION
I added a mod-config white/black list for the builder block so that people can specify what blocks the builder block can copy with NBT data.

add your block name to the list. Set its value to true to whitelist it and false to blacklist it. Blocks not included in the list are blacklisted by default.

It is recommended not to whitelist blocks that can hold items to prevent item duplication.