### PR TITLE
1.18 Made Builder Block NBT data copying configurable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,12 +46,34 @@ sourceSets.main.resources {
     srcDir 'src/generated/resources'
 }
 
+repositories {
+    maven {
+        url = "https://cursemaven.com"
+        content {
+            includeGroup "curse.maven"
+        }
+    }
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = "Modrinth"
+                url = "https://api.modrinth.com/maven"
+            }
+        }
+        filter {
+            includeGroup "maven.modrinth"
+        }
+    }
+}
+
 dependencies {
     mc()
     top()
     jei()
     mcjtylib()
     rftoolsbase()
+    runtimeOnly(fg.deobf("curse.maven:rftools-utility-342466:4938941"))
+    runtimeOnly(fg.deobf("curse.maven:rftools-power-290209:4087998"))
 }
 
 cfdeps(['the-one-probe'], ['mcjtylib', 'rftools-base'], [])

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 1.18-4.1.4:
+- PHOBOSS added a block blacklist/whitelist configuration option to allow NBT transfer of selected blocks
+
+1.18-4.1.4:
 - Lennyservant added a fix so that the builder's fake player gets used correctly in all cases
 
 1.18-4.1.3:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 modname=RFToolsBuilder
-version=1.18-4.1.4
+version=1.18-4.1.5
 curse_type=release
 projectId=347706
 projectSlug=rftools-builder

--- a/src/main/java/mcjty/rftoolsbuilder/modules/builder/BlockInformation.java
+++ b/src/main/java/mcjty/rftoolsbuilder/modules/builder/BlockInformation.java
@@ -9,11 +9,12 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class BlockInformation {
 
     private static Map<ResourceLocation,BlockInformation> blockInformationMap = null;
-
+    private static Map<ResourceLocation,Boolean> blackWhiteListedNBTBlocksMap = null;
     private final ResourceLocation blockName;
     private final SupportBlock.SupportStatus blockLevel;
     private final double costFactor;
@@ -34,6 +35,23 @@ public class BlockInformation {
             return ROTATE_mfff;
         } else {
             return ROTATE_invalid;
+        }
+    }
+
+    private static void initBlackWhiteListedNBTBlocksMap() {
+        if (blackWhiteListedNBTBlocksMap == null) {
+            blackWhiteListedNBTBlocksMap = new HashMap<>();
+            List<? extends String> blocks = BuilderConfiguration.blackWhiteListedNBTBlocks.get();
+            Boolean whitelist = false;
+            for (String block : blocks) {
+                if (block.contains("=")) {
+                    String[] split = block.split("=");
+                    block = split[0];
+                    whitelist = Boolean.valueOf(split[1]);
+                }
+                ResourceLocation id = new ResourceLocation(block);
+                blackWhiteListedNBTBlocksMap.put(id,whitelist);
+            }
         }
     }
 
@@ -85,6 +103,11 @@ public class BlockInformation {
     public static BlockInformation getBlockInformation(Block block) {
         initMap();
         return blockInformationMap.get(Tools.getId(block));
+    }
+
+    public static boolean shouldTransferNBT(Block block) {
+        initBlackWhiteListedNBTBlocksMap();
+        return blackWhiteListedNBTBlocksMap.getOrDefault(Tools.getId(block), false);
     }
 
     public SupportBlock.SupportStatus getBlockLevel() {

--- a/src/main/java/mcjty/rftoolsbuilder/modules/builder/BuilderConfiguration.java
+++ b/src/main/java/mcjty/rftoolsbuilder/modules/builder/BuilderConfiguration.java
@@ -29,6 +29,11 @@ public class BuilderConfiguration {
     };
     public static ForgeConfigSpec.ConfigValue<List<? extends String>> blackWhiteListedBlocks;
 
+    private static String[] blackWhiteListedNBTBlocksAr = new String[] {
+            "minecraft:chest=false"
+    };
+    public static ForgeConfigSpec.ConfigValue<List<? extends String>> blackWhiteListedNBTBlocks;
+
     public static ForgeConfigSpec.BooleanValue showProgressHud;
 
     public static ForgeConfigSpec.IntValue maxSpaceChamberDimension;
@@ -93,6 +98,9 @@ public class BuilderConfiguration {
         blackWhiteListedBlocks = SERVER_BUILDER
                 .comment("This is a list of blocks that are either blacklisted or whitelisted from the Builder when it tries to move tile entities (format <id>=<cost>)")
                 .defineList("blackWhiteListedBlocks", Lists.newArrayList(blackWhiteListedBlocksAr), s -> s instanceof String);
+        blackWhiteListedNBTBlocks = SERVER_BUILDER
+                .comment("Whitelist or blacklist block NBT data from being transferred over, set `true` to whitelist block, set `false` to blacklist block, every block not included in the list is blacklisted by default (format <id>=<boolean>)")
+                .defineList("blackWhiteListedNBTBlocks", Lists.newArrayList(blackWhiteListedNBTBlocksAr), s -> s instanceof String);
         maxSpaceChamberDimension = SERVER_BUILDER
                 .comment("Maximum dimension for the space chamber")
                 .defineInRange("maxSpaceChamberDimension", 128, 0, 100000);

--- a/src/main/java/mcjty/rftoolsbuilder/modules/builder/blocks/BuilderTileEntity.java
+++ b/src/main/java/mcjty/rftoolsbuilder/modules/builder/blocks/BuilderTileEntity.java
@@ -1754,6 +1754,13 @@ public class BuilderTileEntity extends TickingTileEntity implements IHudSupport 
             }
             if (!destWorld.getBlockState(destPos).isAir()) {
                 destWorld.setBlock(destPos, newState, Block.UPDATE_ALL);  // placeBlockAt can reset the orientation. Restore it here
+
+                BlockEntity srcTileEntity = srcWorld.getBlockEntity(srcPos);
+                if (srcTileEntity != null) {
+                    Block srcBlock = srcState.getBlock();
+                    CompoundTag tc = transferNBT(srcBlock,srcTileEntity);
+                    setTileEntityNBT(destWorld, tc, destPos, srcState);
+                }
             }
 
             if (!ItemStack.matches(consumedStack, takeableItem.peek())) { // Did we actually use up whatever we were holding?
@@ -1871,6 +1878,14 @@ public class BuilderTileEntity extends TickingTileEntity implements IHudSupport 
         return false;
     }
 
+    private CompoundTag transferNBT(Block srcBlock,BlockEntity srcTileEntity) {
+        if(BlockInformation.shouldTransferNBT(srcBlock)) {
+            return srcTileEntity.saveWithFullMetadata();
+        }else {
+            return srcTileEntity.saveWithoutMetadata();
+        }
+    }
+
     private void moveBlock(Level srcWorld, BlockPos srcPos, Level destWorld, BlockPos destPos, RotateMode rotMode) {
         BlockState oldDestState = destWorld.getBlockState(destPos);
         Block oldDestBlock = oldDestState.getBlock();
@@ -1898,7 +1913,7 @@ public class BuilderTileEntity extends TickingTileEntity implements IHudSupport 
 
             CompoundTag tc = null;
             if (srcTileEntity != null) {
-                tc = srcTileEntity.saveWithoutMetadata();
+                tc = transferNBT(srcBlock,srcTileEntity);
                 srcWorld.removeBlockEntity(srcPos);
             }
             clearBlock(srcWorld, srcPos);
@@ -1936,7 +1951,14 @@ public class BuilderTileEntity extends TickingTileEntity implements IHudSupport 
         BlockState oldDstState = destWorld.getBlockState(dstPos);
         Block dstBlock = oldDstState.getBlock();
         BlockEntity dstTileEntity = destWorld.getBlockEntity(dstPos);
-
+        CompoundTag srcTC = null;
+        CompoundTag dstTC = null;
+        if (srcTileEntity != null) {
+            srcTC = transferNBT(srcBlock,srcTileEntity);
+        }
+        if (dstTileEntity != null) {
+            dstTC = transferNBT(dstBlock,dstTileEntity);
+        }
         if (isEmpty(oldSrcState, srcBlock) && isEmpty(oldDstState, dstBlock)) {
             return;
         }
@@ -1971,21 +1993,15 @@ public class BuilderTileEntity extends TickingTileEntity implements IHudSupport 
         BlockState newDstState = oldSrcState;
         destWorld.setBlock(dstPos, newDstState, Block.UPDATE_ALL);
 //        destWorld.setBlockMetadataWithNotify(destX, destY, destZ, srcMeta, 3);
-        if (srcTileEntity != null) {
-            srcTileEntity.clearRemoved();
-            destWorld.setBlockEntity(srcTileEntity);
-            srcTileEntity.setChanged();
-            destWorld.sendBlockUpdated(dstPos, newDstState, newDstState, Block.UPDATE_ALL);
+        if (srcTC != null) {
+            setTileEntityNBT(destWorld, srcTC, dstPos, newDstState);
         }
 
         BlockState newSrcState = oldDstState;
         srcWorld.setBlock(srcPos, newSrcState, Block.UPDATE_ALL);
 //        world.setBlockMetadataWithNotify(x, y, z, dstMeta, 3);
-        if (dstTileEntity != null) {
-            dstTileEntity.clearRemoved();
-            srcWorld.setBlockEntity(dstTileEntity);
-            dstTileEntity.setChanged();
-            srcWorld.sendBlockUpdated(srcPos, newSrcState, newSrcState, Block.UPDATE_ALL);
+        if (dstTC != null) {
+            setTileEntityNBT(srcWorld, dstTC, srcPos, newSrcState);
         }
 
         if (!silent) {


### PR DESCRIPTION
I added a mod-config white/black list for the builder block so that people can specify what blocks the builder block can copy with NBT data.

add your block name to the list. Set its value to true to whitelist it and false to blacklist it. Blocks not included in the list are blacklisted by default.

It is recommended not to whitelist blocks that can hold items to prevent item duplication.