### PR TITLE
[1.21_neo] Fix: Use the right api for partial ticks

### DIFF
--- a/src/main/java/mcjty/rftoolsbuilder/modules/mover/client/MoverRenderer.java
+++ b/src/main/java/mcjty/rftoolsbuilder/modules/mover/client/MoverRenderer.java
@@ -31,7 +31,6 @@ import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.client.event.ViewportEvent;
 import net.neoforged.neoforge.client.model.data.ModelData;
 import org.jetbrains.annotations.NotNull;
-
 import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -49,7 +48,7 @@ public class MoverRenderer {
     public static final int LINES_SUPPORTED = 7;
 
     public static float getPartialTicks() {
-        return Minecraft.getInstance().getFrameTimeNs(); // @todo 1.21 is this right? getFrameTime();
+        return Minecraft.getInstance().getTimer().getGameTimeDeltaPartialTick(false);
     }
 
     public static void actualRender(MoverTileEntity mover, @NotNull GuiGraphics graphics, Vec3 cameraPos, ItemStack card, Vec3 current, Vec3 offset,


### PR DESCRIPTION
Following the [1.21 Migration Guide](https://github.com/neoforged/.github/blob/main/primers/1.21/index.md#delta-tracker) the [net.minecraft.client.Minecraft.getFrameTime()](https://nekoyue.github.io/ForgeJavaDocs-NG/javadoc/1.20.6-neoforge/net/minecraft/client/Minecraft.html#getFrameTime()) method is replaced by [net.minecraft.client.Minecraft.getTimer().getGameTimeDeltaPartialTick(false)](https://nekoyue.github.io/ForgeJavaDocs-NG/javadoc/1.21.x-neoforge/net/minecraft/client/DeltaTracker.Timer.html#getGameTimeDeltaPartialTick(boolean)).

Currently getFrameTimeNs() also outputs way to high numbers and breaks rendering?
