### PR TITLE
Fix #173: shape data packet uses the unclamped dimension, crashing dedicated servers for cards over 512

### DIFF
--- a/src/main/java/mcjty/rftoolsbuilder/modules/builder/items/ShapeCardItem.java
+++ b/src/main/java/mcjty/rftoolsbuilder/modules/builder/items/ShapeCardItem.java
@@ -470,6 +470,20 @@ public class ShapeCardItem extends Item implements IComponentsToPreserve, IToolt
         return new BlockPos(clampDimension(dimension.getX(), maximum), clampDimension(dimension.getY(), maximum), clampDimension(dimension.getZ(), maximum));
     }
 
+    // Shape preview and saved shape data are generated from a dimension clamped to these
+    // limits. Every site that generates, sizes or decodes that data has to agree on the
+    // clamp, otherwise the producer and the consumer disagree about how big a plane is.
+    public static final int MAX_SHAPE_DATA_HORIZONTAL = 512;
+    public static final int MAX_SHAPE_DATA_VERTICAL = 4096;
+
+    public static BlockPos getShapeDataDimension(ItemStack card) {
+        BlockPos dimension = getDimension(card);
+        return new BlockPos(
+                clampDimension(dimension.getX(), MAX_SHAPE_DATA_HORIZONTAL),
+                clampDimension(dimension.getY(), MAX_SHAPE_DATA_VERTICAL),
+                clampDimension(dimension.getZ(), MAX_SHAPE_DATA_HORIZONTAL));
+    }
+
     private static int clampDimension(int o, int maximum) {
         if (o > maximum) {
             o = maximum;
@@ -561,8 +575,7 @@ public class ShapeCardItem extends Item implements IComponentsToPreserve, IToolt
     }
 
     public static int getRenderPositions(ItemStack stack, boolean solid, RLE positions, StatePalette statePalette, IFormula formula, int oy) {
-        BlockPos dimension = ShapeCardItem.getDimension(stack);
-        BlockPos clamped = new BlockPos(Math.min(dimension.getX(), 512), Math.min(dimension.getY(), 4096), Math.min(dimension.getZ(), 512));
+        BlockPos clamped = getShapeDataDimension(stack);
 
         int dx = clamped.getX();
         int dy = clamped.getY();
@@ -597,8 +610,7 @@ public class ShapeCardItem extends Item implements IComponentsToPreserve, IToolt
 
     // Used for saving
     public static int getDataPositions(Level world, ItemStack stack, Shape shape, boolean solid, RLE positions, StatePalette statePalette) {
-        BlockPos dimension = ShapeCardItem.getDimension(stack);
-        BlockPos clamped = new BlockPos(Math.min(dimension.getX(), 512), Math.min(dimension.getY(), 4096), Math.min(dimension.getZ(), 512));
+        BlockPos clamped = getShapeDataDimension(stack);
 
         IFormula formula = shape.getFormulaFactory().get();
         int dx = clamped.getX();

--- a/src/main/java/mcjty/rftoolsbuilder/modules/scanner/network/PacketRequestShapeData.java
+++ b/src/main/java/mcjty/rftoolsbuilder/modules/scanner/network/PacketRequestShapeData.java
@@ -43,9 +43,7 @@ public record PacketRequestShapeData(ItemStack card, ShapeID shapeID, int checks
             Shape shape = ShapeCardItem.getShape(card);
             boolean shapeSolid = ShapeCardItem.isSolid(card);
             boolean optimizeRenderShell = shapeID.isSolid();
-            BlockPos dimension = ShapeCardItem.getDimension(card);
-
-            BlockPos clamped = new BlockPos(Math.min(dimension.getX(), 512), Math.min(dimension.getY(), 4096), Math.min(dimension.getZ(), 512));
+            BlockPos clamped = ShapeCardItem.getShapeDataDimension(card);
             int dy = clamped.getY();
             ItemStack copy = card.copy();
 

--- a/src/main/java/mcjty/rftoolsbuilder/shapes/ShapeDataManagerServer.java
+++ b/src/main/java/mcjty/rftoolsbuilder/shapes/ShapeDataManagerServer.java
@@ -104,7 +104,9 @@ public class ShapeDataManagerServer {
 
                 ItemStack card = unit.getStack();
                 boolean solid = unit.isOptimizeRenderShell();
-                BlockPos dimension = ShapeCardItem.getDimension(card);
+                // Must match the clamp getRenderPositions() generates with, or the packet
+                // describes a plane larger than the RLE actually contains.
+                BlockPos dimension = ShapeCardItem.getShapeDataDimension(card);
 
                 RLE positions = new RLE();
                 StatePalette statePalette = new StatePalette();


### PR DESCRIPTION
Fixes #173. Thanks to @beefkit for the original report and analysis — this PR is essentially their diagnosis, deduplicated.

## The bug

Shape preview and shape-data generation clamp each horizontal axis to 512, so `ShapeCardItem.getRenderPositions` emits exactly `min(x,512) * min(z,512)` RLE entries per plane. But `ShapeDataManagerServer.handleWork` reads the **unclamped** `ShapeCardItem.getDimension(card)` and puts that in the packet, so `PacketReturnShapeData.encodePositions` sizes its expectation as `dimension.getX() * dimension.getZ()`.

For any card with X or Z over 512 the producer and the consumer disagree, and `packPositions` throws out of a world-tick listener with no handler, taking the dedicated server down:

```
java.lang.IllegalStateException: Unexpected packed plane length: got 24576, expected 36096
  at PacketReturnShapeData.packPositions(PacketReturnShapeData.java:492)
  ...
  at ShapeHandler.onWorldTick(ShapeHandler.java:13)
```

The formula holds across every card reported so far:

| card (X × Z) | produced = min(X,512)·min(Z,512) | expected = X·Z |
|---|---|---|
| 699 × 344 (#173) | 176128 | 240456 |
| 555 × 681 (#173) | 262144 | 377955 |
| 752 × 48 (mine) | 24576 | 36096 |

## Why it isn't only the packed codec

`encodePositions` runs the `PACKED_BITS` encoder whenever `projectorCompressionLogging` is true — which is the default — even when the selected codec is `LEGACY_RLE`, then discards the result. So this reproduces on default config.

Setting `projectorCompressionLogging = false` avoids the server crash but does not reconcile the dimensions. The packet still carries the unclamped value and the client calls `createPositionReader(dx * dz)`; reading the source, `RleReader.read()` returns empty only once `produced >= expectedCount` and throws `Corrupt RLE plane payload` when the RLE runs out first. So the mismatch is worth fixing at the source rather than only suppressing the encoder.

## The fix

The 512/4096 clamp was written out longhand in three places (`PacketRequestShapeData.handle`, `getRenderPositions`, `getDataPositions`) and missing in the fourth (`handleWork`) — which is how the two sides drifted apart. This extracts it to one `ShapeCardItem.getShapeDataDimension(card)`, built on the existing `clampDimension` helper, and uses it at all four sites.

Fixing `handleWork` also corrects two things that follow from the same mismatch:

- the preview was mis-centred by `(X-512)/2` blocks, since the server generates centred on the clamped width while the client centres on the unclamped one
- `planeSurfacePerTick` was over-subtracted using the unclamped area, throttling previews harder than configured

For cards at or under 512 on both axes the clamp is a no-op, so there is no behaviour change in the common case.

## Testing

`./gradlew compileJava` passes. Verified against 1.21-7.0.5 on a dedicated server: four reproducible crashes from a 752×48 quarry card, with arithmetic matching the table above.

## Two follow-ups, happy to split out or drop

1. `projectorCompressionLogging` defaults to `true`, which runs the experimental comparison encoder on every preview plane in production for a stat line. Intentional?
2. The preview path hardcodes 512 while `Formulas` uses `ScannerConfiguration.maxScannerDimension` for the same concept. Should the preview honour the config instead? I left that alone deliberately since it changes a tunable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)